### PR TITLE
SPDX2: Support supplier and originator

### DIFF
--- a/pkg/formats/spdx/spdx.go
+++ b/pkg/formats/spdx/spdx.go
@@ -3,6 +3,28 @@
 
 package spdx
 
+import "strings"
+
 const (
 	NOASSERTION = "NOASSERTION"
 )
+
+func ParseActorString(s string) (actorType, actorName, actorEmail string) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "Person:") {
+		actorType = "person"
+		s = strings.TrimPrefix(s, "Person:")
+	} else if strings.HasPrefix(s, "Organization:") {
+		actorType = "org"
+		s = strings.TrimPrefix(s, "Organization:")
+	}
+	s = strings.TrimSpace(s)
+	actorName = s
+	if strings.HasSuffix(s, ")") && strings.Contains(s, "(") {
+		actorName = strings.TrimSpace(s[0:strings.LastIndex(s, "(")])
+		actorEmail = strings.TrimSpace(s[strings.LastIndex(s, "(")+1:])
+		actorEmail = strings.TrimSuffix(actorEmail, ")")
+	}
+
+	return actorType, actorName, actorEmail
+}

--- a/pkg/formats/spdx/spdx_test.go
+++ b/pkg/formats/spdx/spdx_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright 2023 The OneSBOM Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package spdx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseActorString(t *testing.T) {
+	for _, tc := range []struct {
+		sut        string
+		actorName  string
+		actorType  string
+		actorEmail string
+	}{
+		{"Organization: Peanuts", "Peanuts", "org", ""},
+		{"Person: Charlie Brown", "Charlie Brown", "person", ""},
+		{"Person: Woodstock Bird (woodstock@peanuts.com)", "Woodstock Bird", "person", "woodstock@peanuts.com"},
+		{"Organization: Peanuts Corporation (corp@peanuts.com)", "Peanuts Corporation", "org", "corp@peanuts.com"},
+	} {
+		y, n, e := ParseActorString(tc.sut)
+		require.Equal(t, tc.actorType, y)
+		require.Equal(t, tc.actorName, n)
+		require.Equal(t, tc.actorEmail, e)
+	}
+
+}

--- a/pkg/reader/spdx/v22/parser.go
+++ b/pkg/reader/spdx/v22/parser.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/onesbom/onesbom/pkg/formats/spdx"
 	spdx23 "github.com/onesbom/onesbom/pkg/formats/spdx/v23"
 	"github.com/onesbom/onesbom/pkg/license"
 	"github.com/onesbom/onesbom/pkg/reader/options"
@@ -72,6 +73,28 @@ func (s *Parser) ParseJSON(opts *options.Options, f io.Reader) (*sbom.Document, 
 					Type:  extid.Type,
 					Value: extid.Locator,
 				})
+			}
+		}
+
+		if spdxDoc.Packages[i].Supplier != "" {
+			actorType, actorName, actorEmail := spdx.ParseActorString(spdxDoc.Packages[i].Supplier)
+			if actorType != "" {
+				p.Supplier = &sbom.Person{
+					Name:  actorName,
+					Email: actorEmail,
+					IsOrg: (actorType == "org"),
+				}
+			}
+		}
+
+		if spdxDoc.Packages[i].Originator != "" {
+			actorType, actorName, actorEmail := spdx.ParseActorString(spdxDoc.Packages[i].Originator)
+			if actorType != "" {
+				p.Originator = &sbom.Person{
+					Name:  actorName,
+					Email: actorEmail,
+					IsOrg: (actorType == "org"),
+				}
 			}
 		}
 

--- a/pkg/reader/spdx/v23/parser.go
+++ b/pkg/reader/spdx/v23/parser.go
@@ -72,6 +72,28 @@ func (s *Parser) ParseJSON(opts *options.Options, f io.Reader) (*sbom.Document, 
 			}
 		}
 
+		if spdxDoc.Packages[i].Supplier != "" {
+			actorType, actorName, actorEmail := spdx.ParseActorString(spdxDoc.Packages[i].Supplier)
+			if actorType != "" {
+				p.Supplier = &sbom.Person{
+					Name:  actorName,
+					Email: actorEmail,
+					IsOrg: (actorType == "org"),
+				}
+			}
+		}
+
+		if spdxDoc.Packages[i].Originator != "" {
+			actorType, actorName, actorEmail := spdx.ParseActorString(spdxDoc.Packages[i].Originator)
+			if actorType != "" {
+				p.Originator = &sbom.Person{
+					Name:  actorName,
+					Email: actorEmail,
+					IsOrg: (actorType == "org"),
+				}
+			}
+		}
+
 		// License data
 		if spdxDoc.Packages[i].LicenseDeclared != spdx.NOASSERTION {
 			p.License = license.Expression(spdxDoc.Packages[i].LicenseDeclared)


### PR DESCRIPTION
This commit adds support to parse the supplier and originator data from packages in SPDX2 SBOMs.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>